### PR TITLE
Update pom for release process

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,12 @@
 	<name>StudyMetaData</name>
 	<description>HPHCI My Studies Web Services</description>
 	<url>https://github.com/FDA-MyStudies/WCP-WS</url>
+	<scm>
+		<connection>scm:git:https://github.com/FDA-MyStudies/WCP-WS</connection>
+		<developerConnection>scm:git:https://github.com/FDA-MyStudies/WCP-WS</developerConnection>
+		<url>https://github.com/FDA-MyStudies</url>
+		<tag>HEAD</tag>
+	</scm>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.hphc.mystudies</groupId>
 	<artifactId>StudyMetaData</artifactId>
-	<version>21.3.0-SNAPSHOT</version>
+	<version>21.3-SNAPSHOT</version>
 	<packaging>war</packaging>
 	<name>StudyMetaData</name>
 	<description>HPHCI My Studies Web Services</description>


### PR DESCRIPTION
We will use the maven release plugin to produce non-snapshot releases. The plugin requires SCM information.
Also updating the version number here to be consistent with LabKey SNAPSHOT versioning.